### PR TITLE
Changes with ico-validator usage

### DIFF
--- a/ares.gemspec
+++ b/ares.gemspec
@@ -16,13 +16,14 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'ico-validator', '0.3.1'
+
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'rails'
-  spec.add_development_dependency 'ico-validator'
 
   spec.add_runtime_dependency 'httparty'
   spec.add_runtime_dependency 'nokogiri'

--- a/ares.gemspec
+++ b/ares.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'ico-validator', '0.3.1'
+  spec.add_dependency 'ico-validator', '~> 0.4'
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/ares.rb
+++ b/lib/ares.rb
@@ -28,10 +28,9 @@ module Ares
     private
 
     def validate_ico_format(ico)
-      return unless ico.present?
-      validator = ::IcoValidator.new(attributes: [:_])
-      return if validator.send(:valid_ico?, ico)
-      fail ArgumentError, "ICO '#{ico}' is invalid"
+      unless IcoValidation.valid_ico?(ico)
+        fail ArgumentError, "ICO '#{ico}' is invalid"
+      end
     end
   end
 end

--- a/lib/ares/version.rb
+++ b/lib/ares/version.rb
@@ -1,3 +1,3 @@
 module Ares
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
In first commit fix current version, in second commit use new ico-validator and it's public api